### PR TITLE
Accept SSML / inputHints for managing session / Alexa ChannelData / Alexa Card support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ It has six configuration settings:
 * `msglocale="en-US"` - The locale for the message language
 * `APPINSIGHTS_INSTRUMENTATIONKEY` - The instrumentation key for appinsignts - comment out the appinsights code if you aren't using it. 
 * `leaveSessionOpen` - Set this to "false" to end the session by default (i.e. Alexa does not wait for further input) or "true" to wait for input and use the promptPhrase to prompt the user if they do not say anything else
+* `useHeroCardAttachmentAsAlexaCard` - Set this to "true" to have the bridge use a Bot Framework Hero Card attachment to construct an Alexa card (the title, text and image from the Hero Card to populate the Alexa card). By default this is disabled unless this variable exists and is set to "true".
 * [Check out the quickstart](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-nodejs-quick-start)
 
 ### Starting the alexa-bridge
@@ -117,6 +118,20 @@ At this point you should be able to use the test page on the Alexa Skill configu
 ### Start the Bot
 
 How you do this depends on whether you're in Node or C#, but I'm trusting you can figure this out.
+
+### Channel Data
+
+By default the ChannelData property on the Acitivity object sent to your bot is populated with the following properties;
+
+* Alexa Session Id (session_sessionId)
+* Alexa User Id (user_userId)
+* Linked Account Access Token (user_accessToken - if account linking is enabled for the skill and the user has successfully linked their account)
+* User Permissions (user_permissions)
+* Alexa Api Access Token (alexa_apiAccessToken)
+* Alexa Api Endpoint (alexa_apiEndpoint)
+* Device (device)
+
+The above properties will allow you to do things like check the type of Alexa device being used, the permissions that the user has accepted (such as allowing you to see their full or partial address), or send progressive messages / notifications using Alexa Apis (via the Alexa Api Access Token and Endpoint).
 
 ### Managing conversation via Bot
 

--- a/README.md
+++ b/README.md
@@ -87,13 +87,15 @@ Now we can start the bridge, but let's do a quick bit of configuration first:
 ### Configuring the alexa-bridge
 
 Create a file called in the solution called .env
-It has five configuration settings:
+It has six configuration settings:
 
 * `botId` - The Bot identity in the conversation. This won't actually be seen anywhere at present.
 * `directLineSecret` - The secret created when setting up the DirectLine channel for the Bot.
 * `promptPhrase="Can I help you with anything else?"` - This is the phrase used to prompt the user to continue the conversation
 * `msglocale="en-US"` - The locale for the message language
-* `APPINSIGHTS_INSTRUMENTATIONKEY` - The instrumentation key for appinsignts - comment out the appinsights code if you aren't using it. [Check out the quickstart](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-nodejs-quick-start)
+* `APPINSIGHTS_INSTRUMENTATIONKEY` - The instrumentation key for appinsignts - comment out the appinsights code if you aren't using it. 
+* `leaveSessionOpen` - Set this to "false" to end the session by default (i.e. Alexa does not wait for further input) or "true" to wait for input and use the promptPhrase to prompt the user if they do not say anything else
+* [Check out the quickstart](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-nodejs-quick-start)
 
 ### Starting the alexa-bridge
 
@@ -115,6 +117,26 @@ At this point you should be able to use the test page on the Alexa Skill configu
 ### Start the Bot
 
 How you do this depends on whether you're in Node or C#, but I'm trusting you can figure this out.
+
+### Managing conversation via Bot
+
+The Bot Framework SDK allows you to either send text based messages, or alternatively (when using channels like Cortana) to send SSML for more granular control over how something is spoken.  This bridge now supports both, using the 'text' property on the activity by default, but allowing this to be overridden by the 'speak' property if SSML has been specified.
+
+The bridge will also look for inputHints on the incoming activity from the bot, specifically looking for the 'expectingInput' hint, which will cause the bridge to leave the conversation open and allow the user to say something else without explicitly invoking the skill again.
+
+Below is an example of using the above features in a C# bot. In this example we send some basic SSML from the bot to the bridge and also indicate that we are expecting an answer from the user.
+
+```
+var messageText = "What would you like to do next?";
+var speakText = "<speak>Thanks! I say, What would you like to do next?</speak>";
+var messageOptions = new MessageOptions
+            {
+                InputHint = InputHints.ExpectingInput
+            };
+await context.SayAsync(messageText, speakText, options: messageOptions);
+```
+
+There is also an app setting 'leaveSessionOpen' which, if set to "true", will leave the session open and accept more input by default without needing to specify it explicitly using the inputHint.  However, having this set to false will allow you to only wait for more input from the user when it makes sense for your bot.
 
 ### Publishing this project to an Azure App Service
 

--- a/lib/alexaBridge.js
+++ b/lib/alexaBridge.js
@@ -64,8 +64,9 @@ function botSays(activity) {
       "version": "1.0",
       "response": {
         "outputSpeech": {
-          "type": "PlainText",
-          "text": activity.text
+          "type": (activity.speak) ? "SSML" : "PlainText",
+          "text": activity.text,
+          "ssml": (activity.speak) ? ((activity.speak.lastIndexOf("<speak>", 0) === 0) ? activity.speak : "<speak>" + activity.speak + "</speak>" ) : null
         },
         "reprompt": {
           "outputSpeech": {
@@ -73,7 +74,9 @@ function botSays(activity) {
             "text": process.env.promptPhrase || "Can I help you with anything else?"  // provides the prompt phrase if the user doesn't ask another question after the first answer is send to them
           }
         },
-        "shouldEndSession" : false  // assumes we will keep the session open to anable conversations through the bridge without needing to use the trigger word for the skill in Alexa more than once.
+        "shouldEndSession" : ((activity.inputHint) && (activity.inputHint == 'expectingInput')) 
+        ? false // Looks for inputHints on the incoming activity from the bot and checks for 'éxpectingInput', which will leave the session open.
+        : ((process.env.leaveSessionOpen && process.env.leaveSessionOpen == 'true') ? false : true)   // If no inputHint is found then check if the 'leaveSessionOpen' app setting exists and is set to 'true' - if it is leave the session open, otherwise close the session by default
       }
     };
 

--- a/lib/alexaBridge.js
+++ b/lib/alexaBridge.js
@@ -80,6 +80,24 @@ function botSays(activity) {
       }
     };
 
+    if(process.env.useHeroCardAttachmentAsAlexaCard 
+      && process.env.useHeroCardAttachmentAsAlexaCard == 'true' 
+      && activity.attachments && activity.attachments[0] 
+      && activity.attachments[0].contentType == "application/vnd.microsoft.card.hero")
+    {
+      var card = { 
+        "type": "Standard",
+        "title": activity.attachments[0].content.title,
+        "text": activity.attachments[0].content.text,
+        "image": {
+          "smallImageUrl": activity.attachments[0].content.images[0].url,
+          "largeImageUrl": activity.attachments[0].content.images[0].url
+          }
+      };
+      
+      reply.response.card = card;
+    }
+
     if (activity.replyToId in responses) {
       console.log("SEND IMMEDIATELY");
       // We've matched the conversation id so we can send back the conversation to Alexa immediately.
@@ -112,12 +130,23 @@ function alexaIntent(req, res, bot, next) {
 
   let startTime = Date.now();
 
+  var channelData = {
+    session_sessionId : (req.body.session.sessionId) ? req.body.session.sessionId : null,
+    user_userId : (req.body.session.user.userId) ? req.body.session.user.userId : null,
+    user_accessToken : (req.body.session.user.accessToken) ? req.body.session.user.accessToken : null,
+    user_permissions : (req.body.session.user.permissions) ? req.body.session.user.permissions : null,
+    alexa_apiAccessToken : (req.body.context.System.apiAccessToken) ? req.body.context.System.apiAccessToken : null,
+    alexa_apiEndpoint :  (req.body.context.System.apiEndpoint) ? req.body.context.System.apiEndpoint : null,
+    device : (req.body.context.System.device) ? req.body.context.System.device : null
+  };
+
   var activity = {
     type : "message",
     text : utterance,
     from : { id : userId },
     locale : process.env.msglocale || "en-US",
-    timestamp : (new Date()).toISOString()
+    timestamp : (new Date()).toISOString(),
+    channelData : channelData
   };
 
   // Forward the activity to our Bot


### PR DESCRIPTION
…vity if this exists - falling back to the text property if it does not). Updated the logic around the 'shouldEndSession' property on the Alexa skill response to default to true, but this can be overridden using inputHints on incoming activities from the bot, or globally using a new app setting 'leaveSessionOpen'. Also updated readme with details and a C# example of new SSML / session ending capabilities.