### PR TITLE
Support multiple bot responses/performance enhancements/bug fixes/deployment feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ jspm_packages
 
 #vscode
 .vscode
+.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,21 @@
 			"request": "launch",
 			"name": "Launch Program",
 			"program": "${workspaceRoot}/server.js",
-			"cwd": "${workspaceRoot}"
+			"cwd": "${workspaceRoot}",
+			"env": {
+				"botId" : "",
+				"directLineSecret" : "",
+				"APPINSIGHTS_INSTRUMENTATIONKEY" : "",
+				"promptPhrase"	: "Can I help with anything else?",
+				"progressiveResponse" : "Working on it for you",
+				"msglocale" : "en-US",
+				"leaveSessionOpen" : "false",
+				"useHeroCardAttachmentAsAlexaCard" : "false",
+				"useMultipleResponses" : "true",
+				"multipleResponsesTimeout" : "3000",
+				"useWebsocket" : "true",
+				"directLineDomain": "https://directline.botframework.com/v3/directline"
+			}			
 		},
 		{
 			"type": "node",

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Take the public endpoint for the 3979 (or whatever you choose) port and use as t
 
 ## Start the alexa-bridge
 
-The easiest way to deploy this is to use the `Deploy to Azure` button above, all the following settings will automatically be setup for you.  Recommend that you deploy this to the `West US` data center to reduce latency between the Alexa <> Bridge <> Bot.
+The easiest way to deploy this is to use the `Deploy to Azure` button above, all the following settings will automatically be setup for you.  Recommend that you deploy this to the same data center to where you Azure Bot Service is reduce latency between the Alexa <> Bridge <> Bot.
 The bridge will automatically start after deployment so should be good to go.
 
 ### Configuring the alexa-bridge
@@ -125,7 +125,8 @@ The following application keys are required, you can set these in your launch.js
 | `useHeroCardAttachmentAsAlexaCard` | `false` | Set this to "true" to have the bridge use a Bot Framework Hero Card attachment to construct an Alexa card (the title, text and image from the Hero Card to populate the Alexa card). By default this is disabled unless this variable exists and is set to "true" |
 |`progressiveResponse` | `Working in it` | The busy message that you want Alexa to say whilst results are being retrieved from your bot |
 |`useMultipleResponses` | `true` | Set this to true if your bot responds with more than 1 message in any response |
-|`multipleResponsesTimeout` | `4000` | Time in milliseconds that any buffered responses from your bot will be released to Alexa.  If you have long running tasks, set this value slightly longer than they take.  However, careful setting this value to large (4+ milliseconds) as your bot responses will be ignored and you'll g et the standard Alexa timeout response instead |
+|`multipleResponsesTimeout` | `3000` | Time in milliseconds that any buffered responses from your bot will be released to Alexa.  If you have long running tasks, set this value slightly longer than they take.  However, careful setting this value to large (4+ milliseconds) as your bot responses will be ignored and you'll g et the standard Alexa timeout response instead |
+|`useWebsocket` | `true` | Use websockets vs polling DirectLine connector service |
 |`directLineDomain` | `https://directline.botframework.com/v3/directline` |You can tweak this setting depending on your geographic region - the default should be fine. Possible options are: https://directline.botframework.com/v3/directline  https://asia.directline.botframework.com/v3/directline * https://europe.directline.botframework.com/v3/directline * https://northamerica.directline.botframework.com/v3/directline |
 
 ### Starting the alexa-bridge

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A bridge between Alexa Skills and the Microsoft Bot SDK
 
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fdaltskin%2Falexa-bridge%2Fmaster%2Fdeploy%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
 # Overview
 
 This is a simple restify-based server that acts as a bridge between an Alexa Skill and a Microsoft Bot Framework bot. Utterances originating at an Alexa endpoint e.g. an Echo device are received by this bridge, translated and forwarded to the Microsoft Bot. Replies coming back from the Bot are then returned to the originating endpoint. Alexa will read out the text in the `Text` field of the Bot reply.

--- a/assets/alexa_model_example.json
+++ b/assets/alexa_model_example.json
@@ -1,0 +1,45 @@
+{
+    "interactionModel": {
+        "languageModel": {
+            "invocationName": "demo",
+            "intents": [
+                {
+                    "name": "AMAZON.CancelIntent",
+                    "samples": []
+                },
+                {
+                    "name": "AMAZON.HelpIntent",
+                    "samples": []
+                },
+                {
+                    "name": "AMAZON.StopIntent",
+                    "samples": []
+                },
+                {
+                    "name": "GetUserIntent",
+                    "slots": [
+                        {
+                            "name": "phrase",
+                            "type": "phrase"
+                        }
+                    ],
+                    "samples": [
+                        "{phrase}"
+                    ]
+                }
+            ],
+            "types": [
+                {
+                    "name": "phrase",
+                    "values": [
+                        {
+                            "name": {
+                                "value": "GetUserIntent asdf {phrase}"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -130,7 +130,13 @@
                         "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
                     ],
                     "properties": {
-                        "alwaysOn": true
+                        "alwaysOn": true,
+                        "requestTracingEnabled": false,
+                        "remoteDebuggingEnabled": false,
+                        "remoteDebuggingVersion": null,
+                        "httpLoggingEnabled": false,
+                        "logsDirectorySizeLimit": 35,
+                        "detailedErrorLoggingEnabled": false
                     }
                 },
                 {

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -8,40 +8,27 @@
                 "description": "The name of the web app that you wish to create."
             }
         },
-        "hostingPlanName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the App Service plan to use for hosting the web app."
-            }
+        "serverFarmId": {
+            "type": "string"
         },
-        "hostingEnvironment": {
+        "createServerFarm": {
+            "type": "bool"
+        },
+        "serverFarmLocation": {
             "type": "string",
             "defaultValue": ""
         },        
-        "sku": {
-            "type": "string",
-            "defaultValue": "Standard",
-            "metadata": {
-                "description": "The pricing tier for the hosting plan."
+        "serverFarmSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
             }
         },
-        "skuCode": {
-            "type": "string",
-            "defaultValue": "S1"
-        },        
-        "workerSize": {
-            "type": "string",
-            "allowedValues": [
-                "0",
-                "1",
-                "2"
-            ],
-            "defaultValue": "0",
-            "metadata": {
-                "description": "The instance size of the hosting plan (small, medium, or large)."
-            }
-        },
-        "linuxFxVersion": {
+        "nodeVersion": {
             "type": "string",
             "defaultValue": "node|9.4"
         },
@@ -61,7 +48,6 @@
         },
         "botId": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "Azure Bot Service Bot Id (not MSA App ID)"
             }
@@ -73,72 +59,128 @@
                 "description": "Azure Bot Service Direct Line Channel Secret - get this from the Azure Bot Service portal"
             }
         },
-        "appInsightsInstrumentationKey": {
+        "appInsightsInstrumentationLocation": {
             "type": "string",
-            "defaultValue": "",
+            "allowedValues": [
+                "East US",
+                "North Europe",
+                "South Central US",
+                "Southeast Asia",
+                "West Europe",
+                "West US 2"
+            ],
             "metadata": {
-                "description": "Application Insights key to store bridge activity"
+                "description": "Application Insights Location"
             }
-        }        
+        }
+    },
+    "variables": {
+        "appInsightsName": "[concat(parameters('botId'), '-alexabridge')]",
+        "serverFarmName": "[last(split(parameters('serverFarmId'), '/'))]"        
     },
     "resources": [
         {
-            "apiVersion": "2016-09-01",
-            "name": "[parameters('hostingPlanName')]",
             "type": "Microsoft.Web/serverfarms",
-            "kind": "linux",
+            "condition": "[parameters('createServerFarm')]",
+            "name": "[variables('serverFarmName')]",
+            "apiVersion": "2016-09-01",
             "location": "[resourceGroup().location]",
-            "sku": {
-                "Tier": "[parameters('sku')]",
-                "Name": "[parameters('skuCode')]"
-            },
+            "sku": "[parameters('serverFarmSku')]",
             "properties": {
-                "name": "[parameters('hostingPlanName')]",
-                "workerSizeId": "[parameters('workerSize')]",
-                "reserved": true,
-                "numberOfWorkers": "1",
-                "hostingEnvironment": "[parameters('hostingEnvironment')]"
+                "name": "[variables('serverFarmName')]"
             }
         },
         {
-            "apiVersion": "2016-08-01",
+            "name": "[variables('appInsightsName')]",
+            "type": "microsoft.insights/components",
+            "kind": "web",
+            "apiVersion": "2015-05-01",
+            "location": "[parameters('appInsightsInstrumentationLocation')]",
+            "tags": {
+                "[concat('hidden-link:', resourceId('Microsoft.BotService/botServices/', parameters('botId')))]": "Resource",
+                "[concat('hidden-link:', resourceId('Microsoft.Web/sites/', parameters('siteName')))]": "Resource"
+            },
+            "properties": {
+                "ApplicationId": "[parameters('botId')]"
+            }
+        },
+        {
+            "apiVersion": "2015-08-01",
             "name": "[parameters('siteName')]",
             "type": "Microsoft.Web/sites",
-            "kind": "app,linux",
+            "kind": "app",
             "location": "[resourceGroup().location]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]"
+
+                "[resourceId('microsoft.insights/components/', variables('appInsightsName'))]"
             ],
             "properties": {
                 "name": "[parameters('siteName')]",
-                "httpsOnly" : "true",
+                "httpsOnly": "true",
+                "serverFarmId": "[variables('serverFarmName')]",
                 "siteConfig": {
-                    "linuxFxVersion": "[parameters('linuxFxVersion')]"
+                    "alwaysOn": true,
+                    "clientAffinityEnabled ": false,                    
+                    "appSettings": [
+                        {
+                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                            "value": "6.9.1"
+                        },
+                        {
+                            "name": "botId",
+                            "value": "[parameters('botId')]"
+                        },
+                        {
+                            "name": "directLineSecret",
+                            "value": "[parameters('directLineSecret')]"
+                        },
+                        {
+                            "name": "promptPhrase",
+                            "value": "Can I help you with anything else?"
+                        },
+                        {
+                            "name": "progressiveResponse",
+                            "value": "I'm just looking that up for you"
+                        },
+                        {
+                            "name": "msglocale",
+                            "value": "en-US"
+                        },
+                        {
+                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                            "value": "[reference(resourceId('microsoft.insights/components/', variables('appInsightsName')), '2015-05-01').InstrumentationKey]"
+                        },
+                        {
+                            "name": "leaveSessionOpen",
+                            "value": "false"
+                        },
+                        {
+                            "name": "useHeroCardAttachmentAsAlexaCard",
+                            "value": "false"
+                        },
+                        {
+                            "name": "useMultipleResponses",
+                            "value": "true"
+                        },
+                        {
+                            "name": "multipleResponsesTimeout",
+                            "value": "3000"
+                        },
+                        {
+                            "name": "useWebsocket",
+                            "value": "true"
+                        },                        
+                        {
+                            "name": "directLineDomain",
+                            "value": "https://directline.botframework.com/v3/directline"
+                        }
+                    ]
                 },
-                "serverFarmId": "[parameters('hostingPlanName')]",
-                "hostingEnvironment": "[parameters('hostingEnvironment')]"
+                "dependsOn": [
+                    "[concat('Microsoft.Web/serverfarms/', variables('serverFarmName'))]"
+                ]
             },
-            "dependsOn": [
-                "[concat('Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]"
-            ],
             "resources": [
-                {
-                    "apiVersion": "2016-08-01",
-                    "name": "web",
-                    "type": "config",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
-                    ],
-                    "properties": {
-                        "alwaysOn": true,
-                        "requestTracingEnabled": false,
-                        "remoteDebuggingEnabled": false,
-                        "remoteDebuggingVersion": null,
-                        "httpLoggingEnabled": false,
-                        "logsDirectorySizeLimit": 35,
-                        "detailedErrorLoggingEnabled": false
-                    }
-                },
                 {
                     "apiVersion": "2015-08-01",
                     "name": "web",
@@ -151,28 +193,7 @@
                         "branch": "[parameters('branch')]",
                         "IsManualIntegration": true
                     }
-                },
-                {
-                    "apiVersion": "2015-08-01",
-                    "name": "appsettings",
-                    "type": "config",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
-                    ],
-                    "properties": {
-                        "botId": "[parameters('botId')]",
-                        "directLineSecret": "[parameters('directLineSecret')]",
-                        "promptPhrase": "Can I help you with anything else?",
-                        "progressiveResponse" : "I'm just looking that up for you",
-                        "msglocale": "en-US",
-                        "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('appInsightsInstrumentationKey')]",
-                        "leaveSessionOpen": "false",
-                        "useHeroCardAttachmentAsAlexaCard": "false",
-                        "useMultipleResponses": "true",
-                        "multipleResponsesTimeout": "3000",
-                        "directLineDomain": "https://directline.botframework.com/v3/directline"
-                    }
-                }              
+                }
             ]
         }
     ]

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -14,10 +14,6 @@
         "createServerFarm": {
             "type": "bool"
         },
-        "serverFarmLocation": {
-            "type": "string",
-            "defaultValue": ""
-        },        
         "serverFarmSku": {
             "type": "object",
             "defaultValue": {
@@ -27,10 +23,6 @@
                 "family": "S",
                 "capacity": 1
             }
-        },
-        "nodeVersion": {
-            "type": "string",
-            "defaultValue": "node|9.4"
         },
         "repoURL": {
             "type": "string",

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -157,6 +157,7 @@
                         "botId": "[parameters('botId')]",
                         "directLineSecret": "[parameters('directLineSecret')]",
                         "promptPhrase": "Can I help you with anything else?",
+                        "progressiveResponse" : "I'm just looking that up for you",
                         "msglocale": "en-US",
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('appInsightsInstrumentationKey')]",
                         "leaveSessionOpen": "false",

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -111,6 +111,7 @@
             ],
             "properties": {
                 "name": "[parameters('siteName')]",
+                "httpsOnly" : "true",
                 "siteConfig": {
                     "linuxFxVersion": "[parameters('linuxFxVersion')]"
                 },
@@ -153,7 +154,18 @@
                         "multipleResponsesTimeout": "3000",
                         "directLineDomain": "https://directline.botframework.com/v3/directline"
                     }
-                }
+                },
+                {
+                    "apiVersion": "2016-08-01",
+                    "name": "[concat(parameters('sites_jdfab1_name'), '/', 'web')]",
+                    "type": "Microsoft.Web/sites/config",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
+                    ],
+                    "properties": {
+                        "alwaysOn": true
+                    }
+                }                
             ]
         }
     ]

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -157,8 +157,8 @@
                 },
                 {
                     "apiVersion": "2016-08-01",
-                    "name": "[concat(parameters('sites_jdfab1_name'), '/', 'web')]",
-                    "type": "Microsoft.Web/sites/config",
+                    "name": "web",
+                    "type": "config",
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
                     ],

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -1,0 +1,160 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "siteName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the web app that you wish to create."
+            }
+        },
+        "hostingPlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service plan to use for hosting the web app."
+            }
+        },
+        "hostingEnvironment": {
+            "type": "string",
+            "defaultValue": ""
+        },        
+        "sku": {
+            "type": "string",
+            "defaultValue": "Standard",
+            "metadata": {
+                "description": "The pricing tier for the hosting plan."
+            }
+        },
+        "skuCode": {
+            "type": "string",
+            "defaultValue": "S1"
+        },        
+        "workerSize": {
+            "type": "string",
+            "allowedValues": [
+                "0",
+                "1",
+                "2"
+            ],
+            "defaultValue": "0",
+            "metadata": {
+                "description": "The instance size of the hosting plan (small, medium, or large)."
+            }
+        },
+        "linuxFxVersion": {
+            "type": "string",
+            "defaultValue": "node|9.4"
+        },
+        "repoURL": {
+            "type": "string",
+            "defaultValue": "https://github.com/daltskin/alexa-bridge.git",
+            "metadata": {
+                "description": "The URL for the GitHub repository that contains the project to deploy."
+            }
+        },
+        "branch": {
+            "type": "string",
+            "defaultValue": "master",
+            "metadata": {
+                "description": "The branch of the GitHub repository to use."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Azure Bot Service Bot Id (not MSA App ID)"
+            }
+        },
+        "directLineSecret": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Azure Bot Service Direct Line Channel Secret - get this from the Azure Bot Service portal"
+            }
+        },
+        "appInsightsInstrumentationKey": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Application Insights key to store bridge activity"
+            }
+        }        
+    },
+    "resources": [
+        {
+            "apiVersion": "2016-09-01",
+            "name": "[parameters('hostingPlanName')]",
+            "type": "Microsoft.Web/serverfarms",
+            "kind": "linux",
+            "location": "[resourceGroup().location]",
+            "sku": {
+                "Tier": "[parameters('sku')]",
+                "Name": "[parameters('skuCode')]"
+            },
+            "properties": {
+                "name": "[parameters('hostingPlanName')]",
+                "workerSizeId": "[parameters('workerSize')]",
+                "reserved": true,
+                "numberOfWorkers": "1",
+                "hostingEnvironment": "[parameters('hostingEnvironment')]"
+            }
+        },
+        {
+            "apiVersion": "2016-08-01",
+            "name": "[parameters('siteName')]",
+            "type": "Microsoft.Web/sites",
+            "kind": "app,linux",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]"
+            ],
+            "properties": {
+                "name": "[parameters('siteName')]",
+                "siteConfig": {
+                    "linuxFxVersion": "[parameters('linuxFxVersion')]"
+                },
+                "serverFarmId": "[parameters('hostingPlanName')]",
+                "hostingEnvironment": "[parameters('hostingEnvironment')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Web/serverfarms/', parameters('hostingPlanName'))]"
+            ],
+            "resources": [
+                {
+                    "apiVersion": "2015-08-01",
+                    "name": "web",
+                    "type": "sourcecontrols",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
+                    ],
+                    "properties": {
+                        "RepoUrl": "[parameters('repoURL')]",
+                        "branch": "[parameters('branch')]",
+                        "IsManualIntegration": true
+                    }
+                },
+                {
+                    "apiVersion": "2015-08-01",
+                    "name": "appsettings",
+                    "type": "config",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
+                    ],
+                    "properties": {
+                        "botId": "[parameters('botId')]",
+                        "directLineSecret": "[parameters('directLineSecret')]",
+                        "promptPhrase": "Can I help you with anything else?",
+                        "msglocale": "en-US",
+                        "APPINSIGHTS_INSTRUMENTATIONKEY": "[parameters('appInsightsInstrumentationKey')]",
+                        "leaveSessionOpen": "false",
+                        "useHeroCardAttachmentAsAlexaCard": "false",
+                        "useMultipleResponses": "true",
+                        "multipleResponsesTimeout": "3000",
+                        "directLineDomain": "https://directline.botframework.com/v3/directline"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -123,6 +123,17 @@
             ],
             "resources": [
                 {
+                    "apiVersion": "2016-08-01",
+                    "name": "web",
+                    "type": "config",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
+                    ],
+                    "properties": {
+                        "alwaysOn": true
+                    }
+                },
+                {
                     "apiVersion": "2015-08-01",
                     "name": "web",
                     "type": "sourcecontrols",
@@ -154,18 +165,7 @@
                         "multipleResponsesTimeout": "3000",
                         "directLineDomain": "https://directline.botframework.com/v3/directline"
                     }
-                },
-                {
-                    "apiVersion": "2016-08-01",
-                    "name": "web",
-                    "type": "config",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
-                    ],
-                    "properties": {
-                        "alwaysOn": true
-                    }
-                }                
+                }              
             ]
         }
     ]

--- a/deploy/azuredeploy.parameters.json
+++ b/deploy/azuredeploy.parameters.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "siteName": {
+      "value": "GEN-UNIQUE"
+    },
+    "hostingPlanName": {
+      "value": "GEN-UNIQUE"
+    },
+    "botId": {
+      "value": ""
+    },
+    "directLineSecret": {
+      "value": ""
+    },
+    "appInsightsInstrumentationKey": {
+      "value": ""
+    }      
+  }
+}

--- a/deploy/deploy.ps1
+++ b/deploy/deploy.ps1
@@ -1,0 +1,107 @@
+<#
+ .SYNOPSIS
+    Deploys a template to Azure
+
+ .DESCRIPTION
+    Deploys an Azure Resource Manager template
+
+ .PARAMETER subscriptionId
+    The subscription id where the template will be deployed.
+
+ .PARAMETER resourceGroupName
+    The resource group where the template will be deployed. Can be the name of an existing or a new resource group.
+
+ .PARAMETER resourceGroupLocation
+    Optional, a resource group location. If specified, will try to create a new resource group in this location. If not specified, assumes resource group is existing.
+
+ .PARAMETER deploymentName
+    The deployment name.
+
+ .PARAMETER templateFilePath
+    Optional, path to the template file. Defaults to template.json.
+
+ .PARAMETER parametersFilePath
+    Optional, path to the parameters file. Defaults to parameters.json. If file is not found, will prompt for parameter values based on template.
+#>
+
+param(
+ [Parameter(Mandatory=$True)]
+ [string]
+ $subscriptionId,
+
+ [Parameter(Mandatory=$True)]
+ [string]
+ $resourceGroupName,
+
+ [string]
+ $resourceGroupLocation,
+
+ [Parameter(Mandatory=$True)]
+ [string]
+ $deploymentName,
+
+ [string]
+ $templateFilePath = "azuredeploy.json",
+
+ [string]
+ $parametersFilePath = "azuredeploy.parameters.json"
+)
+
+<#
+.SYNOPSIS
+    Registers RPs
+#>
+Function RegisterRP {
+    Param(
+        [string]$ResourceProviderNamespace
+    )
+
+    Write-Host "Registering resource provider '$ResourceProviderNamespace'";
+    Register-AzureRmResourceProvider -ProviderNamespace $ResourceProviderNamespace;
+}
+
+#******************************************************************************
+# Script body
+# Execution begins here
+#******************************************************************************
+$ErrorActionPreference = "Stop"
+
+# sign in
+Write-Host "Logging in...";
+Login-AzureRmAccount;
+
+# select subscription
+Write-Host "Selecting subscription '$subscriptionId'";
+Select-AzureRmSubscription -SubscriptionID $subscriptionId;
+
+# Register RPs
+$resourceProviders = @("microsoft.cognitiveservices","microsoft.storage","microsoft.web","microsoft.insights","microsoft.botservice");
+if($resourceProviders.length) {
+    Write-Host "Registering resource providers"
+    foreach($resourceProvider in $resourceProviders) {
+        RegisterRP($resourceProvider);
+    }
+}
+
+#Create or check for existing resource group
+$resourceGroup = Get-AzureRmResourceGroup -Name $resourceGroupName -ErrorAction SilentlyContinue
+if(!$resourceGroup)
+{
+    Write-Host "Resource group '$resourceGroupName' does not exist. To create a new resource group, please enter a location.";
+    if(!$resourceGroupLocation) {
+        $resourceGroupLocation = Read-Host "resourceGroupLocation";
+    }
+    Write-Host "Creating resource group '$resourceGroupName' in location '$resourceGroupLocation'";
+    New-AzureRmResourceGroup -Name $resourceGroupName -Location $resourceGroupLocation
+}
+else{
+    Write-Host "Using existing resource group '$resourceGroupName'";
+}
+
+# Start the deployment
+Write-Host "Starting deployment...";
+if(Test-Path $parametersFilePath) {
+    New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile $templateFilePath -TemplateParameterFile $parametersFilePath;
+} else {
+    New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile $templateFilePath;
+}

--- a/deploy/metadata.json
+++ b/deploy/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Deploy Alexa-bridge from GitHub repository",
+  "description": "Deploy this Alexa-Bridge straight into your Azure subscription",
+  "summary": "Deploy a Alexa-bridge from GitHub repository to your Azure Subscription",
+  "githubUsername": "daltskin",
+  "dateUpdated": "2018-04-20"
+}

--- a/lib/alexaBridge.js
+++ b/lib/alexaBridge.js
@@ -1,5 +1,10 @@
 "use strict";
 
+// Connects to AppInsights comment out the following three lines if you aren't using appinsights
+var appInsights = require('applicationinsights');
+appInsights.setup(process.env.APPINSIGHTS_INSTRUMENTATIONKEY).start(); // reads in from APPINSIGHTS_INSTRUMENTATIONKEY by default in the .env file
+let client = appInsights.defaultClient;
+
 var util = require('util');
 var crypto = require('crypto');
 var restify = require('restify');
@@ -8,11 +13,6 @@ var request = require('request');
 
 // This loads the environment variables from the .env file - updated from .config for continuous deployment
 require('dotenv-extended').load();
-
-// Connects to AppInsights comment out the following three lines if you aren't using appinsights
-let appInsights = require('applicationinsights');
-appInsights.setup(process.env.APPINSIGHTS_INSTRUMENTATIONKEY).start(); // reads in from APPINSIGHTS_INSTRUMENTATIONKEY by default in the .env file
-let client = appInsights.client;
 
 // Required to make rxjs ajax run browser-less
 global.XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
@@ -137,6 +137,7 @@ function createAlexaSessionEndReply() {
 // we're against the clock as Alexa will timeout - therefore you can experiment with the timeout setting which will be a comprise of speed of 
 // response to Alexa vs your bot having enough time to finish responding here and to forward on to send on to Alexa.
 function botSays(activity) {
+  let startTime = Date.now();
   console.log("Subscribe event: " + activity.replyToId + " from: " + activity.from.id + " message: " + activity.text);
   //console.log(util.inspect(activity, false, null));
 
@@ -146,6 +147,13 @@ function botSays(activity) {
     msgParts[activity.replyToId] = [activity];
     var reply = createAlexaReply(activity);
     responses[activity.replyToId].push(reply);
+
+    let alexaResponseDuration = Date.now() - startTime;
+    if (client) {
+      client.trackMetric({ name: "Alexa Response Duration", value: alexaResponseDuration });
+    }
+    console.log("Alexa Response Duration: " + alexaResponseDuration);
+
     sendReply(activity.replyToId);
     return;
   }
@@ -167,10 +175,20 @@ function botSays(activity) {
       // Double check we've got the original request message - otherwise we have nothing to respond to and it's gameover for this message
       if (activity.replyToId in responses) {
         responses[activity.replyToId].push(reply);
+
+        let alexaResponseDuration = Date.now() - startTime;
+        if (client) {
+          client.trackMetric({ name: "Alexa Response Duration", value: alexaResponseDuration });
+        }
+        console.log("Alexa Response Duration: " + alexaResponseDuration);
+
         sendReply(activity.replyToId);
       }
       else {
         // Didn't receive this one in time :(
+        if (client){
+          client.trackEvent({name: "Missed message", properties: {"activity.replyToId": activity.replyToId, "activity.text" : activity.text}});
+        }
         console.log("Missed message (not received before timeout): " + activity.replyToId + ": " + activity.text)
       }
     }, process.env.multipleResponsesTimeout);
@@ -179,6 +197,8 @@ function botSays(activity) {
 
 // Alexa called :)
 function alexaIntent(req, res, bot, next) {
+  let startTime = Date.now();
+
   var userId = req.body.session.user.userId;
 
   // Substitute Amazon's default built-in intents - choose how you want to implement these eg. in LUIS
@@ -202,8 +222,6 @@ function alexaIntent(req, res, bot, next) {
   // Bot SDK seems to have some hidden rules regarding valid userId
   // so doing this works around those (else we get 400's)
   userId = crypto.createHmac('md5', userId).digest('hex');
-
-  let startTime = Date.now();
 
   var channelData = {
     session_sessionId: (req.body.session.sessionId) ? req.body.session.sessionId : null,
@@ -230,10 +248,11 @@ function alexaIntent(req, res, bot, next) {
     .subscribe(id => {
       if (id != 'retry') {
 
+        let duration = Date.now() - startTime;
         if (client) {
-          let duration = Date.now() - startTime;
           client.trackMetric({ name: "connector response time", value: duration });
         }
+        console.log("connector response time: " + duration);
 
         // Store the response objects
         responses[id] = [res, next];
@@ -258,6 +277,12 @@ function alexaIntent(req, res, bot, next) {
     }, error => {
       console.warn("failed to send postBack", error);
     });
+
+    let intentDuration = Date.now() - startTime;
+    if (client) {
+      client.trackMetric({ name: "alexaIntent Duration", value: intentDuration });
+    }
+    console.log("alexaIntent response time: " + intentDuration);
 }
 
 // Alexa is calling us with the utterance

--- a/lib/alexaBridge.js
+++ b/lib/alexaBridge.js
@@ -3,7 +3,6 @@
 var util = require('util');
 var crypto = require('crypto');
 var restify = require('restify');
-
 var directLine = require('botframework-directlinejs');
 
 // This loads the environment variables from the .env file - updated from .config for continuous deployment
@@ -20,109 +19,157 @@ global.XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 var config = {}
 config.botId = process.env.botId
 config.directLineSecret = process.env.directLineSecret
+config.domain = process.env.directLineDomain || "https://directline.botframework.com/v3/directline"
 
-var timing = {};
 var responses = {};
+var msgParts = {};
 var botId = config.botId;
 
+// Send our reply to Alexa
 function sendReply(replyToId) {
-
-  // Send our reply to Alexa
-
   var res_next = responses[replyToId];
-  var res = res_next[0]; 
+  var res = res_next[0];
   var next = res_next[1];
   var reply = res_next[2];
   delete responses[replyToId];
+  delete msgParts[replyToId];
 
-  console.log("Replying: ");
-  console.log(reply);
- 
   if (res.send) {
     res.send(reply);
     next();
   }
-  
-  
 }
 
-function botSays(activity) {
+function removeDuplicatesBy(keyFn, array) {
+  var mySet = new Set();
+  return array.filter(function(x) {
+    var key = keyFn(x), isNew = !mySet.has(key);
+    if (isNew) mySet.add(key);
+    return isNew;
+  });
+}
 
-  // This is where messages from the Bot come in.
-  // They could be in response to system messages, unprompted
-  // or replies to our own messages
+// We can have a bunch of messages in state that need to be concatenated into 1 single response for Alexa
+// Here we append them to one another and send the response formatted json.  There can be duplicates if 
+// for example a typing activity (busy) activity has been sent - so these need stripping
+function createAlexaReply(activity) {
+  // Remove any duplicate messages
+  var removeDups = removeDuplicatesBy(x => x.text, msgParts[activity.replyToId]);
 
-  // We see *all* messages in the conversation, forcing us to screen out
-  // the client-originated ones and forward just the bot's replies to previous requests
-  
-  console.log("Bot says: ");
-  console.log(activity);
+  // Create one big long output string to send to Alexa
+  var textOutput = removeDups.reduce(function (a, b) { return a.concat(b.text, ".  ") }, "");
+  var speakOutput = removeDups.reduce(function (a, b) { return ((b.speak) ? a.concat(b.speak, ".  ") : a.concat(b.text, ".  ")) }, "");
+  console.log("Alexa message out: " + textOutput);
 
-  if (activity.from.id == botId && activity.replyToId) {
-
-    var reply = { 
-      "version": "1.0",
-      "response": {
+  var reply = {
+    "version": "1.0",
+    "response": {
+      "outputSpeech": {
+        "type": (activity.speak) ? "SSML" : "PlainText",
+        "text": textOutput,
+        "ssml": (speakOutput) ? ("<speak>" + speakOutput + "</speak>") : null
+      },
+      "reprompt": {
         "outputSpeech": {
-          "type": (activity.speak) ? "SSML" : "PlainText",
-          "text": activity.text,
-          "ssml": (activity.speak) ? ((activity.speak.lastIndexOf("<speak>", 0) === 0) ? activity.speak : "<speak>" + activity.speak + "</speak>" ) : null
-        },
-        "reprompt": {
-          "outputSpeech": {
-            "type": "PlainText",
-            "text": process.env.promptPhrase || "Can I help you with anything else?"  // provides the prompt phrase if the user doesn't ask another question after the first answer is send to them
-          }
-        },
-        "shouldEndSession" : ((activity.inputHint) && (activity.inputHint == 'expectingInput')) 
+          "type": "PlainText",
+          "text": process.env.promptPhrase || "Can I help you with anything else?"  // provides the prompt phrase if the user doesn't ask another question after the first answer is send to them
+        }
+      },
+      //"shouldEndSession" : activity.inputHint == 'expectingInput'
+      "shouldEndSession": ((activity.inputHint) && (activity.inputHint == 'expectingInput'))
         ? false // Looks for inputHints on the incoming activity from the bot and checks for 'éxpectingInput', which will leave the session open.
         : ((process.env.leaveSessionOpen && process.env.leaveSessionOpen == 'true') ? false : true)   // If no inputHint is found then check if the 'leaveSessionOpen' app setting exists and is set to 'true' - if it is leave the session open, otherwise close the session by default
+    }
+  };
+
+  if (process.env.useHeroCardAttachmentAsAlexaCard
+    && process.env.useHeroCardAttachmentAsAlexaCard == 'true'
+    && activity.attachments && activity.attachments[0]
+    && activity.attachments[0].contentType == "application/vnd.microsoft.card.hero") {
+    var card = {
+      "type": "Standard",
+      "title": activity.attachments[0].content.title,
+      "text": activity.attachments[0].content.text,
+      "image": {
+        "smallImageUrl": activity.attachments[0].content.images[0].url,
+        "largeImageUrl": activity.attachments[0].content.images[0].url
       }
     };
 
-    if(process.env.useHeroCardAttachmentAsAlexaCard 
-      && process.env.useHeroCardAttachmentAsAlexaCard == 'true' 
-      && activity.attachments && activity.attachments[0] 
-      && activity.attachments[0].contentType == "application/vnd.microsoft.card.hero")
-    {
-      var card = { 
-        "type": "Standard",
-        "title": activity.attachments[0].content.title,
-        "text": activity.attachments[0].content.text,
-        "image": {
-          "smallImageUrl": activity.attachments[0].content.images[0].url,
-          "largeImageUrl": activity.attachments[0].content.images[0].url
-          }
-      };
-      
-      reply.response.card = card;
-    }
+    reply.response.card = card;
+  }
 
-    if (activity.replyToId in responses) {
-      console.log("SEND IMMEDIATELY");
-      // We've matched the conversation id so we can send back the conversation to Alexa immediately.
-      responses[activity.replyToId].push(reply);
-      sendReply(activity.replyToId);
-    }
-    else {
-      console.log("SEND DEFERRED");
-      // We haven't seen the reply to our initial send yet so we
-      // don't know to which response object we need to send this 
-      // reply, store until we can match to a conversation coming back from the bot framework
+  return reply;
+}
 
-      if (activity.replyToId.indexOf('|')>0) {
-        // greeting messages from the bot framework don't have a pipe in their conversation ID
-        // don't store greeting messages.
-        responses[activity.replyToId] = [reply];
+// Messages back from the bot to Alexa
+// There can be multiple responses back from the bot from a single request.  Problem is that with Alexa we can only send 1 response
+// back, so how do we know when the bot is finished replying?  If your bot is written to only respond with 1 reply to ever request this 
+// isn't a problem, if not we attempt to queue up all the messages back from the bot and send them in one payload back to Alexa.  However,
+// we're against the clock as Alexa will timeout - therefore you can experiment with the timeout setting which will be a comprise of performance
+// of getting your response back to Alexa vs your bot having enough time to process and send all the responses back here to send on to Alexa.
+function botSays(activity) {
+  console.log("Subscribe event: " + activity.replyToId + " from: " + activity.from.id + " message: " + activity.text);
+  //console.log(util.inspect(activity, false, null));
+
+  // When you only have exactly 1 bot response per user request you can safely do this - otherwise you'll need to support
+  // multiple messages coming back from the bot.  However, if message is a user prompt - then we don't want to delay
+  if ((process.env.useMultipleResponses == 'false' || activity.inputHint == 'expectingInput') && activity.replyToId in responses) {
+    msgParts[activity.replyToId] = [activity];
+    var reply = createAlexaReply(activity);
+    responses[activity.replyToId].push(reply);
+    sendReply(activity.replyToId);
+    return;
+  }
+
+  if (activity.replyToId in msgParts) {
+    // Back once again for the renegade master - store additional responses but send them when they've all had chance to come in
+    msgParts[activity.replyToId].push(activity);
+  }
+  else {
+    msgParts[activity.replyToId] = [activity];
+
+    // Max time to wait for all bot responses to come back before we ship them off to Alexa
+    // You can play with the timeout value depending on how long your responses take to come back from your
+    // bot in the case of long running processes.  However, you must get something back to Alexa within <8-10 secs
+    setTimeout(function () {
+
+      var reply = createAlexaReply(activity);
+
+      // Double check we've got the original request message - otherwise we have nothing to respond to and it's gameover for this message
+      if (activity.replyToId in responses) {
+        responses[activity.replyToId].push(reply);
+        sendReply(activity.replyToId);
       }
-    }
+      else {
+        // Didn't receive this one in time :(
+        console.log("Missed message (not received before timeout): " + activity.replyToId + ": " + activity.text)
+      }
+    }, process.env.multipleResponsesTimeout);
   }
 }
 
+// Alexa called :)
 function alexaIntent(req, res, bot, next) {
-
   var userId = req.body.session.user.userId;
-  var utterance = req.body.request.intent.slots.phrase.value;
+
+  // Substitute Amazon's default built-in intents - choose how you want to implement these eg. in LUIS
+  var utterance = "";
+  switch (req.body.request.intent.name) {
+    case "AMAZON.HelpIntent":
+      utterance = "Help";
+      break;
+    case "AMAZON.CancelIntent":
+      utterance = "Cancel"
+      break;
+    case "AMAZON.StopIntent":
+      utterance = "Stop"
+      break;
+    default:
+      utterance = req.body.request.intent.slots.phrase.value;
+  }
+
+  console.log("Alexa utterance: " + utterance);
 
   // Bot SDK seems to have some hidden rules regarding valid userId
   // so doing this works around those (else we get 400's)
@@ -131,105 +178,89 @@ function alexaIntent(req, res, bot, next) {
   let startTime = Date.now();
 
   var channelData = {
-    session_sessionId : (req.body.session.sessionId) ? req.body.session.sessionId : null,
-    user_userId : (req.body.session.user.userId) ? req.body.session.user.userId : null,
-    user_accessToken : (req.body.session.user.accessToken) ? req.body.session.user.accessToken : null,
-    user_permissions : (req.body.session.user.permissions) ? req.body.session.user.permissions : null,
-    alexa_apiAccessToken : (req.body.context.System.apiAccessToken) ? req.body.context.System.apiAccessToken : null,
-    alexa_apiEndpoint :  (req.body.context.System.apiEndpoint) ? req.body.context.System.apiEndpoint : null,
-    device : (req.body.context.System.device) ? req.body.context.System.device : null
+    session_sessionId: (req.body.session.sessionId) ? req.body.session.sessionId : null,
+    user_userId: (req.body.session.user.userId) ? req.body.session.user.userId : null,
+    user_accessToken: (req.body.session.user.accessToken) ? req.body.session.user.accessToken : null,
+    user_permissions: (req.body.session.user.permissions) ? req.body.session.user.permissions : null,
+    alexa_apiAccessToken: (req.body.context.System.apiAccessToken) ? req.body.context.System.apiAccessToken : null,
+    alexa_apiEndpoint: (req.body.context.System.apiEndpoint) ? req.body.context.System.apiEndpoint : null,
+    device: (req.body.context.System.device) ? req.body.context.System.device : null
   };
 
   var activity = {
-    type : "message",
-    text : utterance,
-    from : { id : userId },
-    locale : process.env.msglocale || "en-US",
-    timestamp : (new Date()).toISOString(),
-    channelData : channelData
+    type: "message",
+    text: utterance,
+    from: { id: userId },
+    locale: process.env.msglocale || "en-US",
+    timestamp: (new Date()).toISOString(),
+    channelData: channelData
   };
 
   // Forward the activity to our Bot
   bot.postActivity(activity)
-  .subscribe(id => {
-    if (id != 'retry') {
+    .subscribe(id => {
+      if (id != 'retry') {
 
-      if (client) {
-        let duration = Date.now() - startTime;
-        client.trackMetric({name: "connector response time", value: duration});
-      }
+        if (client) {
+          let duration = Date.now() - startTime;
+          client.trackMetric({ name: "connector response time", value: duration });
+        }
 
-      // id is the replyToId for the message, we're going to
-      // use this match up replies (what the bot says to us) to
-      // repsonse objects (the http transport back to Alexa)
-
-      if (id in responses) {
-        // We've already had the reply from the Bot, send straight away
-        responses[id].unshift(next);
-        responses[id].unshift(res);
-        sendReply(id);
-      }
-      else {
-        // Bot hasn't replied yet, store the response objects until it has
+        // Store the response objects
         responses[id] = [res, next];
       }
-    }
-  }, error => {
-    console.warn("failed to send postBack", error);
-  });
+    }, error => {
+      console.warn("failed to send postBack", error);
+    });
 }
 
+// Alexa is calling us with the utterance
 function alexaSays(req, res, bot, next) {
-  
-  // Alexa is calling us with the utterance
-  console.log("Alexa says:");
-  console.log(util.inspect(req.body, false, null));
-
-  if (req.body && req.body.request && req.body.request.type && 
-      req.body.request.type == "IntentRequest") {
+  //console.log("Alexa says:");
+  //console.log(util.inspect(req.body, false, null));
+  if (req.body && req.body.request && req.body.request.type &&
+    req.body.request.type == "IntentRequest") {
     alexaIntent(req, res, bot, next);
   }
-  else if (req.body && req.body.request && req.body.request.type && 
+  else if (req.body && req.body.request && req.body.request.type &&
     req.body.request.type == "SessionEndedRequest") {
-      // the session has likely timed out from Alexa as no response was received after the prompt.
-      var reply = { 
-        "version": "1.0",
-        "response": {
-          "outputSpeech": {
-            "type": "PlainText",
-            "text": ""
-          },
-          "shouldEndSession" : true  // close the bridge to avoid the "there was a problem with the requested skills response" message from being played after timeout
-        }
-      };
+    // the session has likely timed out from Alexa as no response was received after the prompt.
+    var reply = {
+      "version": "1.0",
+      "response": {
+        "outputSpeech": {
+          "type": "PlainText",
+          "text": ""
+        },
+        "shouldEndSession": true  // close the bridge to avoid the "there was a problem with the requested skills response" message from being played after timeout
+      }
+    };
 
-      console.log("closing the session");
-      res.send(reply);
-      next();
-      
+    console.log("closing the session");
+    res.send(reply);
+    next();
   }
   else {
     return next(new restify.InvalidArgumentError("Unhandled request type"));
-  } 
+  }
 }
 
 function startBridge() {
-
- 
-
-  var opts = { secret : config.directLineSecret, webSocket:false };
+  var opts = {secret:config.directLineSecret, webSocket:false, domain:config.domain};
   var connector = new directLine.DirectLine(opts);
- 
-  connector.activity$.subscribe(
-    botSays,
-    error => console.log("activity$ error", error)
-  );
+
+  connector.activity$
+    .filter(activity => activity.type === 'message' && activity.from.id === botId && activity.replyToId)
+    .subscribe(
+      botSays,
+      error => console.log("activity$ error", error)
+    );
 
   var server = restify.createServer();
   server.use(restify.bodyParser());
-  server.post('/messages', (req, res, err) => alexaSays(req, res, connector, err) );
+  server.post('/messages', (req, res, err) => alexaSays(req, res, connector, err));
 
-  server.listen(process.env.port || process.env.PORT || 8080, function() {
+  server.listen(process.env.port || process.env.PORT || 8080, function () {
     console.log('%s listening at %s', server.name, server.url);
   });
 
@@ -237,7 +268,5 @@ function startBridge() {
 }
 
 module.exports = {
-  start : startBridge
+  start: startBridge
 };
-
-

--- a/lib/alexaBridge.js
+++ b/lib/alexaBridge.js
@@ -4,11 +4,12 @@ var util = require('util');
 var crypto = require('crypto');
 var restify = require('restify');
 var directLine = require('botframework-directlinejs');
+var request = require('request');
 
 // This loads the environment variables from the .env file - updated from .config for continuous deployment
 require('dotenv-extended').load();
 
-// connects to applicationinsights comment out the following three lines if you aren't using appinsights
+// Connects to AppInsights comment out the following three lines if you aren't using appinsights
 let appInsights = require('applicationinsights');
 appInsights.setup(process.env.APPINSIGHTS_INSTRUMENTATIONKEY).start(); // reads in from APPINSIGHTS_INSTRUMENTATIONKEY by default in the .env file
 let client = appInsights.client;
@@ -42,7 +43,7 @@ function sendReply(replyToId) {
 
 function removeDuplicatesBy(keyFn, array) {
   var mySet = new Set();
-  return array.filter(function(x) {
+  return array.filter(function (x) {
     var key = keyFn(x), isNew = !mySet.has(key);
     if (isNew) mySet.add(key);
     return isNew;
@@ -102,12 +103,39 @@ function createAlexaReply(activity) {
   return reply;
 }
 
+function createAlexaProgressReply(requestId) {
+  var reply = {
+    "header": {
+      "requestId": requestId
+    },
+    "directive": {
+      "type": "VoicePlayer.Speak",
+      "speech": process.env.progressiveResponse || "Working on it"
+    }
+  }
+  return reply;
+}
+
+function createAlexaSessionEndReply() {
+  var reply = {
+    "version": "1.0",
+    "response": {
+      "outputSpeech": {
+        "type": "PlainText",
+        "text": ""
+      },
+      "shouldEndSession": true  // close the bridge to avoid the "there was a problem with the requested skills response" message from being played after timeout
+    }
+  };
+  return reply;
+}
+
 // Messages back from the bot to Alexa
 // There can be multiple responses back from the bot from a single request.  Problem is that with Alexa we can only send 1 response
-// back, so how do we know when the bot is finished replying?  If your bot is written to only respond with 1 reply to ever request this 
-// isn't a problem, if not we attempt to queue up all the messages back from the bot and send them in one payload back to Alexa.  However,
-// we're against the clock as Alexa will timeout - therefore you can experiment with the timeout setting which will be a comprise of performance
-// of getting your response back to Alexa vs your bot having enough time to process and send all the responses back here to send on to Alexa.
+// back, so how do we know when the bot is finished replying?  If your bot is written to only respond with 1 reply to every request this 
+// isn't a problem, if not we attempt to queue up all the messages from the bot and send them in one payload back to Alexa.  However,
+// we're against the clock as Alexa will timeout - therefore you can experiment with the timeout setting which will be a comprise of speed of 
+// response to Alexa vs your bot having enough time to finish responding here and to forward on to send on to Alexa.
 function botSays(activity) {
   console.log("Subscribe event: " + activity.replyToId + " from: " + activity.from.id + " message: " + activity.text);
   //console.log(util.inspect(activity, false, null));
@@ -131,7 +159,7 @@ function botSays(activity) {
 
     // Max time to wait for all bot responses to come back before we ship them off to Alexa
     // You can play with the timeout value depending on how long your responses take to come back from your
-    // bot in the case of long running processes.  However, you must get something back to Alexa within <8-10 secs
+    // bot in the case of long running processes.  However, you must get something back to Alexa within <8 secs
     setTimeout(function () {
 
       var reply = createAlexaReply(activity);
@@ -184,7 +212,8 @@ function alexaIntent(req, res, bot, next) {
     user_permissions: (req.body.session.user.permissions) ? req.body.session.user.permissions : null,
     alexa_apiAccessToken: (req.body.context.System.apiAccessToken) ? req.body.context.System.apiAccessToken : null,
     alexa_apiEndpoint: (req.body.context.System.apiEndpoint) ? req.body.context.System.apiEndpoint : null,
-    device: (req.body.context.System.device) ? req.body.context.System.device : null
+    device: (req.body.context.System.device) ? req.body.context.System.device : null,
+    alexa_requestId: (req.body.request.requestId) ? req.body.request.requestId : null
   };
 
   var activity = {
@@ -208,6 +237,23 @@ function alexaIntent(req, res, bot, next) {
 
         // Store the response objects
         responses[id] = [res, next];
+
+        if (activity.channelData) {
+          var busyReply = createAlexaProgressReply(channelData.alexa_requestId);
+          var auth = "Bearer " + activity.channelData.alexa_apiAccessToken;
+
+          var headers = {
+            'Authorization': "Bearer " + activity.channelData.alexa_apiAccessToken
+          };
+
+          request.post({ url: activity.channelData.alexa_apiEndpoint + '/v1/directives', headers: headers, json: busyReply },
+            function (error, response, body) {
+              console.log(response.statusCode)
+              if (!error && response.statusCode == 200) {
+                console.log(body)
+              }
+            });
+        }
       }
     }, error => {
       console.warn("failed to send postBack", error);
@@ -225,17 +271,7 @@ function alexaSays(req, res, bot, next) {
   else if (req.body && req.body.request && req.body.request.type &&
     req.body.request.type == "SessionEndedRequest") {
     // the session has likely timed out from Alexa as no response was received after the prompt.
-    var reply = {
-      "version": "1.0",
-      "response": {
-        "outputSpeech": {
-          "type": "PlainText",
-          "text": ""
-        },
-        "shouldEndSession": true  // close the bridge to avoid the "there was a problem with the requested skills response" message from being played after timeout
-      }
-    };
-
+    var reply = createAlexaSessionEndReply();
     console.log("closing the session");
     res.send(reply);
     next();
@@ -246,7 +282,7 @@ function alexaSays(req, res, bot, next) {
 }
 
 function startBridge() {
-  var opts = {secret:config.directLineSecret, webSocket:false, domain:config.domain};
+  var opts = { secret: config.directLineSecret, webSocket: true, domain: config.domain };
   var connector = new directLine.DirectLine(opts);
 
   connector.activity$
@@ -257,7 +293,7 @@ function startBridge() {
     );
 
   var server = restify.createServer();
-  server.use(restify.bodyParser());
+  server.use(restify.plugins.bodyParser());
   server.post('/messages', (req, res, err) => alexaSays(req, res, connector, err));
 
   server.listen(process.env.port || process.env.PORT || 8080, function () {

--- a/lib/alexaBridge.js
+++ b/lib/alexaBridge.js
@@ -324,7 +324,7 @@ function startBridge() {
     .subscribe(
       botSays,
       error => {
-        console.log("activity$ error", error)
+        console.log("activity$ error", error);
         if (client) {
           client.trackException({exception: new Error(error)});
         }

--- a/lib/alexaBridge.js
+++ b/lib/alexaBridge.js
@@ -15,12 +15,14 @@ var request = require('request');
 require('dotenv-extended').load();
 
 // Required to make rxjs ajax run browser-less
-global.XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+//global.XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+global.XMLHttpRequest = require("xhr2");
 
-var config = {}
-config.botId = process.env.botId
-config.directLineSecret = process.env.directLineSecret
-config.domain = process.env.directLineDomain || "https://directline.botframework.com/v3/directline"
+var config = {};
+config.botId = process.env.botId;
+config.directLineSecret = process.env.directLineSecret;
+config.domain = process.env.directLineDomain || "https://directline.botframework.com/v3/directline";
+config.useWebsocket = process.env.useWebsocket || true;
 
 var responses = {};
 var msgParts = {};
@@ -189,7 +191,7 @@ function botSays(activity) {
         if (client){
           client.trackEvent({name: "Missed message", properties: {"activity.replyToId": activity.replyToId, "activity.text" : activity.text}});
         }
-        console.log("Missed message (not received before timeout): " + activity.replyToId + ": " + activity.text)
+        console.log("Missed message (not received before timeout): " + activity.replyToId + ": " + activity.text);
       }
     }, process.env.multipleResponsesTimeout);
   }
@@ -208,10 +210,10 @@ function alexaIntent(req, res, bot, next) {
       utterance = "Help";
       break;
     case "AMAZON.CancelIntent":
-      utterance = "Cancel"
+      utterance = "Cancel";
       break;
     case "AMAZON.StopIntent":
-      utterance = "Stop"
+      utterance = "Stop";
       break;
     default:
       utterance = req.body.request.intent.slots.phrase.value;
@@ -267,12 +269,12 @@ function alexaIntent(req, res, bot, next) {
 
           request.post({ url: activity.channelData.alexa_apiEndpoint + '/v1/directives', headers: headers, json: busyReply },
             function (error, response, body) {
-              console.log("Progressive response status code: " + response.statusCode)
+              console.log("Progressive response status code: " + response.statusCode);
               if (!error && response.statusCode == 200) {
                 if (client) {
                   client.trackException({exception: new Error(error)});
                 }
-                console.log(body)
+                console.log(body);
               }
             });
         }
@@ -316,7 +318,7 @@ function alexaSays(req, res, bot, next) {
 }
 
 function startBridge() {
-  var opts = { secret: config.directLineSecret, webSocket: true, domain: config.domain };
+  var opts = { secret: config.directLineSecret, webSocket: config.useWebsocket, domain: config.domain };
   var connector = new directLine.DirectLine(opts);
 
   connector.activity$

--- a/lib/alexaBridge.js
+++ b/lib/alexaBridge.js
@@ -267,14 +267,20 @@ function alexaIntent(req, res, bot, next) {
 
           request.post({ url: activity.channelData.alexa_apiEndpoint + '/v1/directives', headers: headers, json: busyReply },
             function (error, response, body) {
-              console.log(response.statusCode)
+              console.log("Progressive response status code: " + response.statusCode)
               if (!error && response.statusCode == 200) {
+                if (client) {
+                  client.trackException({exception: new Error(error)});
+                }
                 console.log(body)
               }
             });
         }
       }
     }, error => {
+      if (client) {
+        client.trackException({exception: new Error(error)});
+      }
       console.warn("failed to send postBack", error);
     });
 
@@ -302,6 +308,9 @@ function alexaSays(req, res, bot, next) {
     next();
   }
   else {
+    if (client) {
+      client.trackException({exception: new Error("Unhandled request type")});
+    }
     return next(new restify.InvalidArgumentError("Unhandled request type"));
   }
 }
@@ -314,7 +323,12 @@ function startBridge() {
     .filter(activity => activity.type === 'message' && activity.from.id === botId && activity.replyToId)
     .subscribe(
       botSays,
-      error => console.log("activity$ error", error)
+      error => {
+        console.log("activity$ error", error)
+        if (client) {
+          client.trackException({exception: new Error(error)});
+        }
+      }
     );
 
   var server = restify.createServer();
@@ -323,6 +337,9 @@ function startBridge() {
 
   server.listen(process.env.port || process.env.PORT || 8080, function () {
     console.log('%s listening at %s', server.name, server.url);
+    if (client) {
+      client.trackEvent({name: "Listening", properties: {"server.name": server.name, "server.url" : server.url}});
+    }
   });
 
   return server;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1223 @@
+{
+  "name": "alexa-bridge",
+  "version": "0.0.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/dotenv": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-4.0.3.tgz",
+      "integrity": "sha512-mmhpINC/HcLGQK5ikFJlLXINVvcxhlrV+ZOUJSN7/ottYl+8X4oSXzS9lBtDkmWAl96EGyGyLrNvk9zqdSH8Fw==",
+      "requires": {
+        "@types/node": "9.6.6"
+      }
+    },
+    "@types/node": {
+      "version": "9.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz",
+      "integrity": "sha512-SJe0g5cZeGNDP5sD8mIX3scb+eq8LQQZ60FXiKZHipYSeEFZ5EKml+NNMiO76F74TY4PoMWlNxF/YRY40FOvZQ=="
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "applicationinsights": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.2.tgz",
+      "integrity": "sha1-XQF8EYWsIsgom7IiBB0l+Cx8MVk=",
+      "requires": {
+        "diagnostic-channel": "0.2.0",
+        "diagnostic-channel-publishers": "0.2.1",
+        "zone.js": "0.7.6"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "auto-parse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/auto-parse/-/auto-parse-1.5.1.tgz",
+      "integrity": "sha512-oL5r9f/DwcBW+Wt6am20XzJhKO7x37p4ZT0yJS0UI2eAgnjeS6ueAjDN6Djx4JKeFw7mU11YWAn3ZlwGNZLPcQ==",
+      "requires": {
+        "typpy": "2.3.10"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "optional": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "botframework-directlinejs": {
+      "version": "0.9.14",
+      "resolved": "https://registry.npmjs.org/botframework-directlinejs/-/botframework-directlinejs-0.9.14.tgz",
+      "integrity": "sha1-zXsMYTuet8GWOgzCpN8Rt6VDYNc=",
+      "requires": {
+        "rxjs": "5.5.10"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "optional": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "0.8.6",
+        "moment": "2.22.1",
+        "mv": "2.1.1",
+        "safe-json-stringify": "1.1.0"
+      }
+    },
+    "camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "optional": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "1.0.4",
+        "path-key": "2.0.1",
+        "semver": "5.5.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
+      }
+    },
+    "csv-parse": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-1.3.3.tgz",
+      "integrity": "sha1-0c/YdDwvhJoKuy/VRNtWaV0ZpJA="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "detect-node": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
+      "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
+    },
+    "diagnostic-channel": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
+      "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+      "requires": {
+        "semver": "5.5.0"
+      }
+    },
+    "diagnostic-channel-publishers": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
+      "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
+    },
+    "dotenv": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+    },
+    "dotenv-extended": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-extended/-/dotenv-extended-2.0.2.tgz",
+      "integrity": "sha512-ovMqj0UXZeseBpRydQ6AHk2PymJRLsZm4ShdGWUT4xMxWwV1PeSqKLFArrurFKsArI8izMGvRt0iEKfuqvWTuw==",
+      "requires": {
+        "@types/dotenv": "4.0.3",
+        "auto-parse": "1.5.1",
+        "camelcase": "5.0.0",
+        "cross-spawn": "6.0.5",
+        "dotenv": "5.0.1",
+        "is-windows": "1.0.2",
+        "lodash": "4.17.5"
+      }
+    },
+    "dtrace-provider": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
+      "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "escape-regexp-component": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz",
+      "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
+    },
+    "ewma": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ewma/-/ewma-2.0.1.tgz",
+      "integrity": "sha512-MYYK17A76cuuyvkR7MnqLW4iFYPEi5Isl2qb8rXiWpLiwFS9dxW/rncuNnjjgSENuVqZQkIuR4+DChVL4g1lnw==",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+      "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
+    },
+    "fast-decode-uri-component": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.0.tgz",
+      "integrity": "sha512-WQSYVKn6tDW/3htASeUkrx5LcnuTENQIZQPCVlwdnvIJ7bYtSpoJYq38MgUJnx1CQIR1gjZ8HJxAEcN4gqugBg=="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "find-my-way": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-1.12.0.tgz",
+      "integrity": "sha512-d7wZ0IeijAZDA/gvHjCNxxRTDCn5j9hnugcgEbNzYhofbDfogGhyRu93mtcJoAxeB1zemWTz9JB2JzNOar/qbA==",
+      "requires": {
+        "fast-decode-uri-component": "1.0.0"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
+    "function.name": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.10.tgz",
+      "integrity": "sha512-IPRArugcDP5O1oRUl2H55GnLNq3CV26bG/dFzLx0AR2dhB/4nj9rIqh1NBdlK7bWlfggV1Q+Aq5Jxafr/+j4BQ==",
+      "requires": {
+        "noop6": "1.0.7"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "optional": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "handle-thing": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
+      }
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "requires": {
+        "inherits": "2.0.3",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "wbuf": "1.7.3"
+      }
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "optional": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        }
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lru-cache": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "optional": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "optional": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "optional": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "moment": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
+      "optional": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "rimraf": "2.4.5"
+      }
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "optional": true
+    },
+    "nconf": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
+      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+      "requires": {
+        "async": "1.5.2",
+        "ini": "1.3.5",
+        "secure-keys": "1.0.0",
+        "yargs": "3.32.0"
+      }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
+    },
+    "noop6": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.7.tgz",
+      "integrity": "sha1-lnZ78gWLpZyoy5FVk0fdyAI5+o4="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "optional": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pidusage": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-1.2.0.tgz",
+      "integrity": "sha512-OGo+iSOk44HRJ8q15AyG570UYxcm5u+R99DI8Khu8P3tKGkVu5EZX4ywHglWSTMNNXQ274oeGpYrvFEhDIFGPg=="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "restify": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/restify/-/restify-7.1.1.tgz",
+      "integrity": "sha512-ijHZGOP1UhRhCU4EpI9WbcLXi4v2xe2/3iqPSLcamjZhL9SkZ8TUfpKLRWHZlxWfL2k6Doy10N1gOnvRS9m5qg==",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "bunyan": "1.8.12",
+        "csv": "1.2.1",
+        "dtrace-provider": "0.8.6",
+        "escape-regexp-component": "1.0.2",
+        "ewma": "2.0.1",
+        "find-my-way": "1.12.0",
+        "formidable": "1.2.1",
+        "http-signature": "1.2.0",
+        "lodash": "4.17.5",
+        "lru-cache": "4.1.2",
+        "mime": "1.6.0",
+        "negotiator": "0.6.1",
+        "once": "1.4.0",
+        "pidusage": "1.2.0",
+        "qs": "6.5.1",
+        "restify-errors": "5.0.0",
+        "semver": "5.5.0",
+        "spdy": "3.4.7",
+        "uuid": "3.2.1",
+        "vasync": "1.6.4",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "csv": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/csv/-/csv-1.2.1.tgz",
+          "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
+          "requires": {
+            "csv-generate": "1.1.2",
+            "csv-parse": "1.3.3",
+            "csv-stringify": "1.1.2",
+            "stream-transform": "0.2.2"
+          }
+        },
+        "csv-generate": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-1.1.2.tgz",
+          "integrity": "sha1-7GsA7a7W5ZrZwgWC9MNk4osUYkA="
+        },
+        "csv-stringify": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
+          "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
+          "requires": {
+            "lodash.get": "4.4.2"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
+          }
+        },
+        "stream-transform": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.2.2.tgz",
+          "integrity": "sha1-dYZ0h/SVKPi/HYJJllh1PQLfeDg="
+        },
+        "vasync": {
+          "version": "1.6.4",
+          "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.4.tgz",
+          "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
+          "requires": {
+            "verror": "1.6.0"
+          },
+          "dependencies": {
+            "verror": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+              "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
+              "requires": {
+                "extsprintf": "1.2.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "restify-errors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/restify-errors/-/restify-errors-5.0.0.tgz",
+      "integrity": "sha512-+vby9Kxf7qlzvbZSTIEGkIixkeHG+pVCl34dk6eKnL+ua4pCezpdLT/1/eabzPZb65ADrgoc04jeWrrF1E1pvQ==",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "lodash": "4.17.5",
+        "safe-json-stringify": "1.1.0",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "rimraf": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+      "optional": true,
+      "requires": {
+        "glob": "6.0.4"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.10",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+      "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safe-json-stringify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.1.0.tgz",
+      "integrity": "sha512-EzBtUaFH9bHYPc69wqjp0efJI/DPNHdFbGE3uIMn4sVbO0zx8vZ8cG4WKxQfOpUOKsQyGBiT2mTqnCw+6nLswA==",
+      "optional": true
+    },
+    "secure-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "spdy": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
+      "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
+      "requires": {
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.1.0"
+      }
+    },
+    "spdy-transport": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
+      "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+      "requires": {
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.1",
+        "wbuf": "1.7.3"
+      }
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "typpy": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.3.10.tgz",
+      "integrity": "sha512-DKiSmYeXF4q+K0H999sVROLjwsngad5AloblLo72No+xVT9W09ytUIOCC/3puHsf+Dsf8M2hoPds0H1HwJgQqg==",
+      "requires": {
+        "function.name": "1.0.10"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.2.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+      "requires": {
+        "minimalistic-assert": "1.0.1"
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "string-width": "1.0.2",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        }
+      }
+    },
+    "zone.js": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.6.tgz",
+      "integrity": "sha1-+7w50+AmHQmG8boGMG6zrrDSIAk="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "nconf": "^0.10.0",
     "request": "^2.85.0",
     "restify": "^7.1.1",
-    "xmlhttprequest": "^1.8.0"
+    "xhr2": "*"
   },
   "files": [
     "server.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-bridge",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "server.js",
   "scripts": {
@@ -9,11 +9,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "applicationinsights": "^0.18.0",
-    "botframework-directlinejs": "^0.7.1",
-    "dotenv-extended": "^2.0.1",
-    "nconf": "^0.8.4",
-    "restify": "^4.3.0",
+    "applicationinsights": "^1.0.2",
+    "botframework-directlinejs": "^0.9.14",
+    "dotenv-extended": "^2.0.2",
+    "nconf": "^0.10.0",
+    "request": "^2.85.0",
+    "restify": "^7.1.1",
     "xmlhttprequest": "^1.8.0"
   },
   "files": [

--- a/web.config
+++ b/web.config
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     This configuration file is required if iisnode is used to run node processes behind
+     IIS or IIS Express.  For more information, visit:
+
+     https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config
+-->
+
+<configuration>
+  <system.webServer>
+    <!-- Visit http://blogs.msdn.com/b/windowsazure/archive/2013/11/14/introduction-to-websockets-on-windows-azure-web-sites.aspx for more information on WebSocket support -->
+    <webSocket enabled="false" />
+    <handlers>
+      <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+      <add name="iisnode" path="server.js" verb="*" modules="iisnode"/>
+    </handlers>
+    <rewrite>
+      <rules>
+        <!-- Do not interfere with requests for node-inspector debugging -->
+        <rule name="NodeInspector" patternSyntax="ECMAScript" stopProcessing="true">
+          <match url="^server.js\/debug[\/]?" />
+        </rule>
+
+        <!-- First we consider whether the incoming URL matches a physical file in the /public folder -->
+        <rule name="StaticContent">
+          <action type="Rewrite" url="public{REQUEST_URI}"/>
+        </rule>
+
+        <!-- All other URLs are mapped to the node.js site entry point -->
+        <rule name="DynamicContent">
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="True"/>
+          </conditions>
+          <action type="Rewrite" url="server.js"/>
+        </rule>
+      </rules>
+    </rewrite>
+    
+    <!-- 'bin' directory has no special meaning in node.js and apps can be placed in it -->
+    <security>
+      <requestFiltering>
+        <hiddenSegments>
+          <remove segment="bin"/>
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
+
+    <!-- Make sure error responses are left untouched -->
+    <httpErrors existingResponse="PassThrough" />
+
+    <!--
+      You can control how Node is hosted within IIS using the following options:
+        * watchedFiles: semi-colon separated list of files that will be watched for changes to restart the server
+        * node_env: will be propagated to node as NODE_ENV environment variable
+        * debuggingEnabled - controls whether the built-in debugger is enabled
+
+      See https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config for a full list of options
+    -->
+    <!--<iisnode watchedFiles="web.config;*.js"/>-->
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
I've made a few changes to allow the following:

- Support multiple responses coming back from the bot (current implementation only responds to the first response in reply) with configurable timeout delay.
- Added Deploy to Azure - make it super easy to deploy this solution (for evaluation and testing) with default parameters and allow botId/directline secret to be entered during provisioning stage
- Added Progressive Response - Will return a "working on it message" whilst data is still be retrieved from the bot to give progress feedback to end user
- Now uses websockets - improve performance of the bridge
- Fixed app insights bug and added more logging
- Added ability to change the directline endpoint

I've tested deploying this in different data centers including West Europe/North Europe and West US.  Regardless of the directline endpoint, West US is the most performant by far (hence added to Readme.md).